### PR TITLE
Feature/markdown custom code blocks

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,6 +50,7 @@ jobs:
         package_path:
           - framework/foundation
           - framework/infrastructure
+          - framework/markdown
           - framework/test-utils
           - product/core
           - product/core-data-sql

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -21,6 +21,8 @@ jobs:
             split_repository: 'framework-foundation'
           - local_path: 'framework/infrastructure'
             split_repository: 'framework-infrastructure'
+          - local_path: 'framework/markdown'
+            split_repository: 'smolblog-markdown'
           - local_path: 'product/core'
             split_repository: 'core'
           - local_path: 'product/core-data-sql'

--- a/packages/framework/markdown/composer.json
+++ b/packages/framework/markdown/composer.json
@@ -6,9 +6,6 @@
         "php": "^8.4",
         "cebe/markdown": "^1.2"
     },
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.8"
-    },
     "license": "Apache-2.0",
     "autoload": {
         "psr-4": {
@@ -25,9 +22,11 @@
             "email": "me@eph.me"
         }
     ],
+    "require-dev": {
+        "smolblog/test-utils": "^0.3"
+    },
     "scripts": {
-        "coverage": "export XDEBUG_MODE=coverage; phpunit --testsuite markdown; cat coverage.txt",
-        "test": "phpunit --testsuite markdown",
+        "test": "phpunit",
         "lint": "./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "lintfix": "./vendor/squizlabs/php_codesniffer/bin/phpcbf"
     }

--- a/packages/framework/markdown/src/Elements/CustomFencedCodeTrait.php
+++ b/packages/framework/markdown/src/Elements/CustomFencedCodeTrait.php
@@ -1,0 +1,55 @@
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.TypeHintMissing
+
+namespace Smolblog\Markdown\Elements;
+
+use cebe\markdown\block\FencedCodeTrait;
+
+/**
+ * A extra layer on top of fenced code blocks that allows language processing.
+ *
+ * By default, a tagged fenced block will include the language. For example:
+ *
+ *     ```php
+ *     $this->mf->process($content);
+ *     ```
+ *
+ * Will be rendered as:
+ *
+ *     <pre><code class="language-php>$this->mf->process($context);</code></pre>
+ *
+ * This allows client-side libraries like Highlight.js to identify and style the code block.
+ *
+ * This trait allows for extra processing during the Markdown->HTML conversion. It provides
+ * an array property $codeRenderers where the keys are programming languages and the values are
+ * callable functions that take the text of the code block and return HTML code. This allows
+ * for server-side code highlighting, or turning the code block into something else entirely!
+ */
+trait CustomFencedCodeTrait {
+	use FencedCodeTrait {
+		renderCode as baseRenderCode;
+	}
+
+	/**
+	 * Store custom code block renderers.
+	 *
+	 * @var array<string, callable>
+	 */
+	protected array $codeRenderers = [];
+
+	/**
+	 * Render a code block.
+	 *
+	 * If the block has a language set and a renderer exists in $this->codeRenderers, that result will
+	 * be returned. Otherwise it is passed through to the base CodeTrait::renderCode method.
+	 *
+	 * @param array $block Block to render.
+	 * @return string
+	 */
+	protected function renderCode($block) {
+		if (isset($block['language']) && array_key_exists($block['language'], $this->codeRenderers)) {
+			return call_user_func($this->codeRenderers[$block['language']], $block);
+		}
+		return $this->baseRenderCode($block);
+	}
+}
+// phpcs:enable Squiz.Commenting.FunctionComment.TypeHintMissing

--- a/packages/framework/markdown/src/Elements/EmbedTrait.php
+++ b/packages/framework/markdown/src/Elements/EmbedTrait.php
@@ -26,7 +26,7 @@ trait EmbedTrait {
 	 * @return boolean
 	 */
 	protected function identifyEmbed(string $line) {
-		return preg_match(static::$embedPattern, $line) === 1;
+		return preg_match(static::$embedPattern, $line) === 1; // @codeCoverageIgnore
 	}
 
 	/**

--- a/packages/framework/markdown/src/SmolblogMarkdown.php
+++ b/packages/framework/markdown/src/SmolblogMarkdown.php
@@ -2,15 +2,15 @@
 
 namespace Smolblog\Markdown;
 
-use cebe\markdown\block\FencedCodeTrait;
 use cebe\markdown\Markdown;
+use Smolblog\Markdown\Elements\CustomFencedCodeTrait;
 use Smolblog\Markdown\Elements\EmbedTrait;
 
 /**
  * Markdown parser with some extra Smolblog flair.
  */
 class SmolblogMarkdown extends Markdown {
-	use FencedCodeTrait;
+	use CustomFencedCodeTrait;
 	use EmbedTrait;
 
 	/**
@@ -23,5 +23,16 @@ class SmolblogMarkdown extends Markdown {
 	) {
 		$this->embedProvider = $embedProvider;
 		$this->html5 = true;
+	}
+
+	/**
+	 * Add a custom handler to the service.
+	 *
+	 * @param string   $language Language this handler is for.
+	 * @param callable $handler  Callable handler for the language.
+	 * @return void
+	 */
+	public function addCustomCodeHandler(string $language, callable $handler): void {
+		$this->codeRenderers[$language] = $handler;
 	}
 }

--- a/packages/framework/markdown/tests/SmolblogMarkdownTest.php
+++ b/packages/framework/markdown/tests/SmolblogMarkdownTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Smolblog\Markdown;
+
+use Smolblog\Test\TestCase;
+
+final class SmolblogMarkdownTest extends TestCase {
+	private EmbedProvider $embed;
+	private SmolblogMarkdown $md;
+
+	public function setUp(): void {
+		$this->embed = $this->createStub(EmbedProvider::class);
+		$this->md = new SmolblogMarkdown(embedProvider: $this->embed);
+	}
+
+	public function testItParsesNormalMarkdown() {
+		$test = <<<EOD
+		# Markdown test #
+
+		There comes a time when things have to happen. This is one of those times.
+
+		## Headers
+
+		There are [inline](https://inline.smol.blog/) links and [reference][ref] links.
+
+		[ref]: https://ref.smol.blog/
+
+		There may even be a way to [directly] say something?
+
+		[directly]: https://directly.smol.blog/
+
+		_wait wait_ this thing has **other colors**?
+
+		### Images
+
+		![An inline image](https://cdn.smolblog.com/inline.jpg)
+
+		![A reference image][img]
+
+		[img]: https://cdn.smolblog.com/ref.jpg
+
+		I love you.
+		EOD;
+
+		$expected = <<<EOD
+		<h1>Markdown test</h1>
+		<p>There comes a time when things have to happen. This is one of those times.</p>
+		<h2>Headers</h2>
+		<p>There are <a href="https://inline.smol.blog/">inline</a> links and <a href="https://ref.smol.blog/">reference</a> links.</p>
+		<p>There may even be a way to <a href="https://directly.smol.blog/">directly</a> say something?</p>
+		<p><em>wait wait</em> this thing has <strong>other colors</strong>?</p>
+		<h3>Images</h3>
+		<p><img src="https://cdn.smolblog.com/inline.jpg" alt="An inline image"></p>
+		<p><img src="https://cdn.smolblog.com/ref.jpg" alt="A reference image"></p>
+		<p>I love you.</p>
+
+		EOD;
+
+		$this->assertEquals($expected, $this->md->parse($test));
+	}
+
+	public function testItFallsBackToALinkIfItCannotEmbed() {
+		$test = <<<EOD
+		# Embed test #
+
+		You know what a really cool video is?
+
+		:[An innocuous YouTube video](https://youtu.be/rTga41r3a4s)
+
+		Rather unexpected, innit?
+		EOD;
+
+		$expected = <<<EOD
+		<h1>Embed test</h1>
+		<p>You know what a really cool video is?</p>
+		<p><a href="https://youtu.be/rTga41r3a4s" target="_blank">An innocuous YouTube video</a></p>
+		<p>Rather unexpected, innit?</p>
+
+		EOD;
+
+		$this->assertEquals($expected, $this->md->parse($test));
+	}
+
+	public function testItInsertsAnEmbedIfDirected() {
+		$test = <<<EOD
+		# Embed test #
+
+		You know what a really cool video is?
+
+		:[An innocuous YouTube video](https://youtu.be/rTga41r3a4s)
+
+		Rather unexpected, innit?
+		EOD;
+
+		$this->embed->method('getEmbedCodeFor')->willReturn('<iframe src="https://embed.youtube.com/watch?v=rTga41r3a4s"></iframe>');
+
+		$expected = <<<EOD
+		<h1>Embed test</h1>
+		<p>You know what a really cool video is?</p>
+		<iframe src="https://embed.youtube.com/watch?v=rTga41r3a4s"></iframe>
+		<p>Rather unexpected, innit?</p>
+
+		EOD;
+
+		$this->assertEquals($expected, $this->md->parse($test));
+	}
+
+	public function testCustomHandlersAreUsedIfPresent() {
+		$sampleHandler = fn($block) => '<div>'.$block['content']."</div>\n";
+		$this->md->addCustomCodeHandler('smol', $sampleHandler);
+
+		$test = <<<EOD
+		# Code test #
+
+		I've got three looks.
+
+		    Indented code block.
+
+		```javascript
+		const answer = 42;
+		```
+
+		```smol
+		The smollest of blogs.
+		```
+
+		And that's it.
+		EOD;
+
+		$expected = <<<EOD
+		<h1>Code test</h1>
+		<p>I've got three looks.</p>
+		<pre><code>Indented code block.
+		</code></pre>
+		<pre><code class="language-javascript">const answer = 42;
+		</code></pre>
+		<div>The smollest of blogs.</div>
+		<p>And that's it.</p>
+
+		EOD;
+
+		$this->assertEquals($expected, $this->md->parse($test));
+	}
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     <include>
       <directory>packages/framework/foundation/src</directory>
       <directory>packages/framework/infrastructure/src</directory>
+      <directory>packages/framework/markdown/src</directory>
       <directory>packages/product/core/src</directory>
       <directory>packages/product/core-data-sql/src</directory>
     </include>


### PR DESCRIPTION
Add a hook for custom-processing of code blocks.

Future uses: server-side code syntax highlighting? Overloading code blocks to get custom formatting + diagrams?